### PR TITLE
Account for comment character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+  - "5.8"
 install:
   - cpanm -n --installdeps .
 sudo: false

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for Pg::ServiceFile
 
 {{$NEXT}}
-    - Improve POD
+    - Account for comment character in connection files (thanks Erik Rijkers!)
 
 0.01  2018-02-23 23:42:06 UTC
     - Initial release

--- a/META.json
+++ b/META.json
@@ -37,7 +37,7 @@
       },
       "runtime" : {
          "requires" : {
-            "Config::INI::Reader" : "0",
+            "Config::Pg::ServiceFile" : "0",
             "Moo" : "0",
             "Types::Path::Tiny" : "0",
             "Types::Standard" : "0",

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ connection service file. It's complete in the fact that it reads the `$ENV{PGSER
 automatically retrieve and merge the system-wide service file or check
 `PGSYSCONFDIR`.
 
+If you know the connection service file you want to use, and just want the data
+as a `HASH` reference, you can use the simpler module [Config::Pg::ServiceFile](https://metacpan.org/pod/Config::Pg::ServiceFile)
+which has less dependencies and features.
+
 # ATTRIBUTES
 
 [Pg::ServiceFile](https://metacpan.org/pod/Pg::ServiceFile) implements the following attributes.
@@ -79,17 +83,24 @@ Returns the names of all the connection services from the service ["file"](#file
 
 ## service
 
+    my $pgservice = Pg::ServiceFile->new(name => 'foo');
+    say $pgservice->service->{dbname}; # db_foo
+
 If ["name"](#name) has been set via `$ENV{PGSERVICE}` or on instantiation, returns
-the corresponding connection service.
+the corresponding connection service. See ["name"](#name).
 
 ## services
 
     my $pgservice = Pg::ServiceFile->new();
-    for my $service ($pgservice->services) {
-        say "$service->{dbname} at $service->{host}";
+    while (my ($name, $service) = each %{$pgservice->services}) {
+        say "[$name] $service->{dbname} at $service->{host}";
     }
 
 Returns a `HASH` of all of the connection services from ["file"](#file).
+
+# CREDITS
+
+> Erik Rijkers
 
 # AUTHOR
 
@@ -106,4 +117,5 @@ it under the same terms as Perl itself.
 
 # SEE ALSO
 
+[Config::Pg::ServiceFile](https://metacpan.org/pod/Config::Pg::ServiceFile),
 [https://www.postgresql.org/docs/current/static/libpq-pgservice.html](https://www.postgresql.org/docs/current/static/libpq-pgservice.html).

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'perl', '5.008005';
 
-requires 'Config::INI::Reader';
+requires 'Config::Pg::ServiceFile';
 requires 'Moo';
 requires 'Types::Path::Tiny';
 requires 'Types::Standard';

--- a/lib/Pg/ServiceFile.pm
+++ b/lib/Pg/ServiceFile.pm
@@ -1,7 +1,7 @@
 package Pg::ServiceFile;
 
 use Moo;
-use Config::INI::Reader;
+use Config::Pg::ServiceFile;
 use Types::Standard qw/ArrayRef HashRef Str/;
 use Types::Path::Tiny 'Path';
 
@@ -42,9 +42,9 @@ has services => (
 
 sub _build_data { shift->file->slurp_utf8 }
 
-sub _build_file { $ENV{PGSERVICEFILE} // '~/.pg_service.conf'}
+sub _build_file { $ENV{PGSERVICEFILE} || '~/.pg_service.conf'}
 
-sub _build_name { $ENV{PGSERVICE} // '' }
+sub _build_name { $ENV{PGSERVICE} || '' }
 
 sub _build_names { [sort keys %{shift->services}] }
 
@@ -53,7 +53,7 @@ sub _build_service {
     return $self->services->{$self->name};
 }
 
-sub _build_services { Config::INI::Reader->read_string(shift->data) }
+sub _build_services { Config::Pg::ServiceFile->read_string(shift->data) }
 
 1;
 
@@ -88,6 +88,10 @@ connection service file. It's complete in the fact that it reads the C<<
 $ENV{PGSERVICEFILE} >> or user service file as standard, but will not
 automatically retrieve and merge the system-wide service file or check
 C<PGSYSCONFDIR>.
+
+If you know the connection service file you want to use, and just want the data
+as a C<HASH> reference, you can use the simpler module L<Config::Pg::ServiceFile>
+which has less dependencies and features.
 
 =head1 ATTRIBUTES
 
@@ -158,6 +162,14 @@ the corresponding connection service. See L</"name">.
 
 Returns a C<HASH> of all of the connection services from L</"file">.
 
+=head1 CREDITS
+
+=over 2
+
+Erik Rijkers
+
+=back
+
 =head1 AUTHOR
 
 Paul Williams E<lt>kwakwa@cpan.orgE<gt>
@@ -173,6 +185,7 @@ it under the same terms as Perl itself.
 
 =head1 SEE ALSO
 
+L<Config::Pg::ServiceFile>,
 L<https://www.postgresql.org/docs/current/static/libpq-pgservice.html>.
 
 =cut

--- a/t/basic.t
+++ b/t/basic.t
@@ -78,6 +78,8 @@ __DATA__
 
 __[ pg_service ]__
 
+# comments are fine
+# but need to be at the beginning of the line
 [foo]
 host=localhost
 port=5432


### PR DESCRIPTION
The commend character for PostgreSQL connection service files is `#` rather
than the `;` I initially had. As such, a new module `Config::Pg::ServiceFile`
has been created to account for the correct comments.

Fixes #1